### PR TITLE
Add minimal P2P color toggle demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# musical-spork
+# p2p-color-toggle
+
+A minimal peer-to-peer demo that syncs the color of a square between two browsers using WebRTC data channels.
+
+## Structure
+- `server/` – Node.js WebSocket signaling server.
+- `client/` – Static HTML/JS client.
+
+## Deploy
+### Server
+Deploy `server/` to any Node hosting (Glitch, Render, Fly.io, etc.).
+```
+cd server
+npm install
+node server.js
+```
+
+### Client
+Serve the files in `client/` via GitHub Pages or any static host.
+
+## Usage
+1. Start the signaling server.
+2. Open `client/index.html` in two browser windows.
+3. Enter the same room code (or share the generated code).
+4. Click the square and watch the color toggle in both windows.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>P2P Color Toggle</title>
+  <style>
+    #square {
+      width: 200px;
+      height: 200px;
+      background: red;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <div id="square"></div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/client/main.js
+++ b/client/main.js
@@ -1,0 +1,69 @@
+const SIGNALING_URL = 'wss://your-signaling-server.example.com';
+
+const square = document.getElementById('square');
+let color = 'red';
+let room = prompt('Room code?');
+if (!room) {
+  room = Math.random().toString(36).substr(2, 4);
+  alert('Your room code: ' + room);
+}
+const codeDisplay = document.createElement('p');
+codeDisplay.textContent = 'Room: ' + room;
+document.body.insertBefore(codeDisplay, square);
+
+const ws = new WebSocket(SIGNALING_URL);
+ws.onopen = () => {
+  ws.send(JSON.stringify({ type: 'join', room }));
+};
+
+const peer = new RTCPeerConnection();
+let dc;
+
+peer.onicecandidate = ({ candidate }) => {
+  if (candidate) {
+    ws.send(JSON.stringify({ type: 'signal', room, data: candidate }));
+  }
+};
+
+function setupDataChannel(channel) {
+  dc = channel;
+  dc.onmessage = (e) => {
+    if (e.data === 'toggle') toggle();
+  };
+}
+
+peer.ondatachannel = (e) => setupDataChannel(e.channel);
+
+ws.onmessage = async (event) => {
+  const msg = JSON.parse(event.data);
+  if (msg.type === 'ready') {
+    dc = peer.createDataChannel('toggle');
+    setupDataChannel(dc);
+    const offer = await peer.createOffer();
+    await peer.setLocalDescription(offer);
+    ws.send(JSON.stringify({ type: 'signal', room, data: offer }));
+  } else if (msg.type === 'signal') {
+    if (msg.data.type === 'offer') {
+      await peer.setRemoteDescription(msg.data);
+      const answer = await peer.createAnswer();
+      await peer.setLocalDescription(answer);
+      ws.send(JSON.stringify({ type: 'signal', room, data: answer }));
+    } else if (msg.data.type === 'answer') {
+      await peer.setRemoteDescription(msg.data);
+    } else if (msg.data.candidate) {
+      await peer.addIceCandidate(msg.data);
+    }
+  }
+};
+
+function toggle() {
+  color = color === 'red' ? 'blue' : 'red';
+  square.style.background = color;
+}
+
+square.onclick = () => {
+  toggle();
+  if (dc && dc.readyState === 'open') {
+    dc.send('toggle');
+  }
+};

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,12 @@
+# Signaling Server
+
+## Setup
+```
+cd server
+npm install
+```
+
+## Run
+```
+node server.js
+```

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "p2p-color-toggle-server",
+  "version": "1.0.0",
+  "main": "server.js",
+  "dependencies": {
+    "ws": "^8.13.0"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,47 @@
+const WebSocket = require('ws');
+
+const port = process.env.PORT || 3000;
+const wss = new WebSocket.Server({ port });
+const rooms = {};
+
+wss.on('connection', (ws) => {
+  ws.on('message', (message) => {
+    let msg;
+    try {
+      msg = JSON.parse(message);
+    } catch (e) {
+      return;
+    }
+    const { type, room, data } = msg;
+    if (!room) return;
+    if (type === 'join') {
+      rooms[room] = rooms[room] || [];
+      if (rooms[room].length < 2) {
+        rooms[room].push(ws);
+      }
+      ws.room = room;
+      if (rooms[room].length === 2) {
+        rooms[room].forEach((s) => s.send(JSON.stringify({ type: 'ready' })));
+      }
+    } else if (type === 'signal') {
+      const peers = rooms[room] || [];
+      peers.forEach((peer) => {
+        if (peer !== ws && peer.readyState === WebSocket.OPEN) {
+          peer.send(JSON.stringify({ type: 'signal', data }));
+        }
+      });
+    }
+  });
+
+  ws.on('close', () => {
+    const room = ws.room;
+    if (room && rooms[room]) {
+      rooms[room] = rooms[room].filter((s) => s !== ws);
+      if (rooms[room].length === 0) {
+        delete rooms[room];
+      }
+    }
+  });
+});
+
+console.log(`Signaling server listening on ${port}`);


### PR DESCRIPTION
## Summary
- add WebSocket signaling server for peer connections
- create vanilla client that toggles square color via WebRTC data channel
- document project structure and deployment steps

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node -c server.js`


------
https://chatgpt.com/codex/tasks/task_e_68927280bbc483249155798c0156dfec