### PR TITLE
Prevent WebRTC offer glare by designating connection initiator

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -21,7 +21,12 @@ wss.on('connection', (ws) => {
       }
       ws.room = room;
       if (rooms[room].length === 2) {
-        rooms[room].forEach((s) => s.send(JSON.stringify({ type: 'ready' })));
+        rooms[room][0].send(
+          JSON.stringify({ type: 'ready', initiator: true })
+        );
+        rooms[room][1].send(
+          JSON.stringify({ type: 'ready', initiator: false })
+        );
       }
     } else if (type === 'signal') {
       const peers = rooms[room] || [];


### PR DESCRIPTION
## Summary
- Signal which peer should create an offer to avoid both peers sending offers simultaneously
- Ignore duplicate answers if connection is already stable

## Testing
- `node server/server.js`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68929d00a88c83249053da20e5252c6a