### PR TITLE
Prevent WebRTC offer glare and synchronize color state

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -2,6 +2,7 @@ const SIGNALING_URL = 'wss://musical-spork.onrender.com';
 
 const square = document.getElementById('square');
 let color = 'red';
+let syncInterval;
 let room = prompt('Room code?');
 if (!room) {
   room = Math.random().toString(36).substr(2, 4);
@@ -18,6 +19,7 @@ ws.onopen = () => {
 
 const peer = new RTCPeerConnection();
 let dc;
+let initiator = false;
 
 peer.onicecandidate = ({ candidate }) => {
   if (candidate) {
@@ -25,10 +27,30 @@ peer.onicecandidate = ({ candidate }) => {
   }
 };
 
+function sendState() {
+  if (dc && dc.readyState === 'open') {
+    dc.send(JSON.stringify({ type: 'state', color }));
+  }
+}
+
 function setupDataChannel(channel) {
   dc = channel;
+  dc.onopen = () => {
+    sendState();
+    syncInterval = setInterval(sendState, 1000);
+  };
+  dc.onclose = () => clearInterval(syncInterval);
   dc.onmessage = (e) => {
-    if (e.data === 'toggle') toggle();
+    let msg;
+    try {
+      msg = JSON.parse(e.data);
+    } catch {
+      return;
+    }
+    if (msg.type === 'state') {
+      color = msg.color;
+      square.style.background = color;
+    }
   };
 }
 
@@ -37,11 +59,14 @@ peer.ondatachannel = (e) => setupDataChannel(e.channel);
 ws.onmessage = async (event) => {
   const msg = JSON.parse(event.data);
   if (msg.type === 'ready') {
-    dc = peer.createDataChannel('toggle');
-    setupDataChannel(dc);
-    const offer = await peer.createOffer();
-    await peer.setLocalDescription(offer);
-    ws.send(JSON.stringify({ type: 'signal', room, data: offer }));
+    initiator = msg.initiator;
+    if (initiator) {
+      dc = peer.createDataChannel('toggle');
+      setupDataChannel(dc);
+      const offer = await peer.createOffer();
+      await peer.setLocalDescription(offer);
+      ws.send(JSON.stringify({ type: 'signal', room, data: offer }));
+    }
   } else if (msg.type === 'signal') {
     if (msg.data.type === 'offer') {
       await peer.setRemoteDescription(msg.data);
@@ -49,7 +74,10 @@ ws.onmessage = async (event) => {
       await peer.setLocalDescription(answer);
       ws.send(JSON.stringify({ type: 'signal', room, data: answer }));
     } else if (msg.data.type === 'answer') {
-      await peer.setRemoteDescription(msg.data);
+      // Avoid applying an answer twice in glare situations
+      if (peer.signalingState !== 'stable') {
+        await peer.setRemoteDescription(msg.data);
+      }
     } else if (msg.data.candidate) {
       await peer.addIceCandidate(msg.data);
     }
@@ -63,7 +91,5 @@ function toggle() {
 
 square.onclick = () => {
   toggle();
-  if (dc && dc.readyState === 'open') {
-    dc.send('toggle');
-  }
+  sendState();
 };

--- a/server/server.js
+++ b/server/server.js
@@ -21,7 +21,12 @@ wss.on('connection', (ws) => {
       }
       ws.room = room;
       if (rooms[room].length === 2) {
-        rooms[room].forEach((s) => s.send(JSON.stringify({ type: 'ready' })));
+        rooms[room][0].send(
+          JSON.stringify({ type: 'ready', initiator: true })
+        );
+        rooms[room][1].send(
+          JSON.stringify({ type: 'ready', initiator: false })
+        );
       }
     } else if (type === 'signal') {
       const peers = rooms[room] || [];


### PR DESCRIPTION
## Summary
- Signal which peer should create an offer to avoid both peers sending offers simultaneously
- Ignore duplicate answers if connection is already stable
- Periodically broadcast full color state over the data channel so peers resynchronize if a message is missed

## Testing
- `node server/server.js`
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68929d00a88c83249053da20e5252c6a