### PR TITLE
Prevent WebRTC offer glare, synchronize color state, and add chat

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -14,6 +14,11 @@
 </head>
 <body>
   <div id="square"></div>
+  <div id="chat">
+    <ul id="log"></ul>
+    <input id="chatInput" placeholder="Type a message" />
+    <button id="sendBtn">Send</button>
+  </div>
   <script src="main.js"></script>
 </body>
 </html>

--- a/client/main.js
+++ b/client/main.js
@@ -1,7 +1,13 @@
 const SIGNALING_URL = 'wss://musical-spork.onrender.com';
 
 const square = document.getElementById('square');
+const log = document.getElementById('log');
+const chatInput = document.getElementById('chatInput');
+const sendBtn = document.getElementById('sendBtn');
 let color = 'red';
+let syncInterval;
+let clientId;
+const messages = [];
 let room = prompt('Room code?');
 if (!room) {
   room = Math.random().toString(36).substr(2, 4);
@@ -18,6 +24,7 @@ ws.onopen = () => {
 
 const peer = new RTCPeerConnection();
 let dc;
+let initiator = false;
 
 peer.onicecandidate = ({ candidate }) => {
   if (candidate) {
@@ -25,10 +32,56 @@ peer.onicecandidate = ({ candidate }) => {
   }
 };
 
+function sendState() {
+  if (dc && dc.readyState === 'open') {
+    dc.send(JSON.stringify({ type: 'state', color }));
+  }
+}
+
+function addMessage(text, sender) {
+  const item = document.createElement('li');
+  item.textContent = `Client ${sender}: ${text}`;
+  log.appendChild(item);
+}
+
+function sendChat(text) {
+  const message = { sender: clientId, text };
+  addMessage(text, clientId);
+  messages.push(message);
+  if (dc && dc.readyState === 'open') {
+    dc.send(JSON.stringify({ type: 'chat', message }));
+  }
+}
+
 function setupDataChannel(channel) {
   dc = channel;
+  dc.onopen = () => {
+    sendState();
+    if (initiator) {
+      dc.send(JSON.stringify({ type: 'chatHistory', messages }));
+    }
+    syncInterval = setInterval(sendState, 1000);
+  };
+  dc.onclose = () => clearInterval(syncInterval);
   dc.onmessage = (e) => {
-    if (e.data === 'toggle') toggle();
+    let msg;
+    try {
+      msg = JSON.parse(e.data);
+    } catch {
+      return;
+    }
+    if (msg.type === 'state') {
+      color = msg.color;
+      square.style.background = color;
+    } else if (msg.type === 'chat') {
+      messages.push(msg.message);
+      addMessage(msg.message.text, msg.message.sender);
+    } else if (msg.type === 'chatHistory') {
+      msg.messages.forEach((m) => {
+        messages.push(m);
+        addMessage(m.text, m.sender);
+      });
+    }
   };
 }
 
@@ -37,11 +90,15 @@ peer.ondatachannel = (e) => setupDataChannel(e.channel);
 ws.onmessage = async (event) => {
   const msg = JSON.parse(event.data);
   if (msg.type === 'ready') {
-    dc = peer.createDataChannel('toggle');
-    setupDataChannel(dc);
-    const offer = await peer.createOffer();
-    await peer.setLocalDescription(offer);
-    ws.send(JSON.stringify({ type: 'signal', room, data: offer }));
+    initiator = msg.initiator;
+    clientId = initiator ? 1 : 2;
+    if (initiator) {
+      dc = peer.createDataChannel('toggle');
+      setupDataChannel(dc);
+      const offer = await peer.createOffer();
+      await peer.setLocalDescription(offer);
+      ws.send(JSON.stringify({ type: 'signal', room, data: offer }));
+    }
   } else if (msg.type === 'signal') {
     if (msg.data.type === 'offer') {
       await peer.setRemoteDescription(msg.data);
@@ -49,7 +106,10 @@ ws.onmessage = async (event) => {
       await peer.setLocalDescription(answer);
       ws.send(JSON.stringify({ type: 'signal', room, data: answer }));
     } else if (msg.data.type === 'answer') {
-      await peer.setRemoteDescription(msg.data);
+      // Avoid applying an answer twice in glare situations
+      if (peer.signalingState !== 'stable') {
+        await peer.setRemoteDescription(msg.data);
+      }
     } else if (msg.data.candidate) {
       await peer.addIceCandidate(msg.data);
     }
@@ -63,7 +123,17 @@ function toggle() {
 
 square.onclick = () => {
   toggle();
-  if (dc && dc.readyState === 'open') {
-    dc.send('toggle');
-  }
+  sendState();
 };
+
+function handleSend() {
+  const text = chatInput.value.trim();
+  if (!text) return;
+  sendChat(text);
+  chatInput.value = '';
+}
+
+sendBtn.onclick = handleSend;
+chatInput.addEventListener('keypress', (e) => {
+  if (e.key === 'Enter') handleSend();
+});

--- a/server/server.js
+++ b/server/server.js
@@ -21,7 +21,12 @@ wss.on('connection', (ws) => {
       }
       ws.room = room;
       if (rooms[room].length === 2) {
-        rooms[room].forEach((s) => s.send(JSON.stringify({ type: 'ready' })));
+        rooms[room][0].send(
+          JSON.stringify({ type: 'ready', initiator: true })
+        );
+        rooms[room][1].send(
+          JSON.stringify({ type: 'ready', initiator: false })
+        );
       }
     } else if (type === 'signal') {
       const peers = rooms[room] || [];


### PR DESCRIPTION
## Summary
- Signal which peer should create an offer to avoid both peers sending offers simultaneously
- Ignore duplicate answers if connection is already stable
- Periodically broadcast full color state over the data channel so peers resynchronize if a message is missed
- Add a basic chat log and input; messages are shared over the data channel and tagged as Client 1 or 2

## Testing
- `node server/server.js`
- `npm test` *(fails: Could not read package.json: Error: ENOENT: no such file or directory, open '/workspace/musical-spork/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68929d00a88c83249053da20e5252c6a